### PR TITLE
Update import 'exec' to have a valid name

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -54,7 +54,7 @@ define sqlite::db(
   if $sql {
     $refresh = ! $enforce_sql
 
-    exec{ "${dbname}-import":
+    exec{ "${name}-import":
       command     => "cat ${sql_inputs} | ${sqlite_cmd} ${safe_location}",
       logoutput   => true,
       refreshonly => $refresh,


### PR DESCRIPTION
The $dbname variable does not exist, it appears it should be $name.
Noticed then when running puppet in test mode the name of the import resource is just "-import" - this will break things badly if more than one db is declared.

    Info: /Stage[main]/Api_server::Database/Sqlite::Db[api_client_cert]/Exec[create_api_client_cert_db]: Scheduling refresh of Exec[-import]